### PR TITLE
Add better DT_RowId generator

### DIFF
--- a/app/controllers/buckets.js
+++ b/app/controllers/buckets.js
@@ -28,8 +28,8 @@ const index = (req, res, next) => {
 }
 
 const create = (req, res, next) => {
-  // Math.random returns a random float between 0 & 1
-  req.body.data[0].DT_RowId = Math.trunc(Math.random() * 1000000.0).toString()
+  // Date.now() is integer number of milliseconds since start of UNIX epoch
+  req.body.data[0].DT_RowId = Date.now()
   const bucketRow = Object.assign(req.body.data[0], {_owner: req.user._id
   })
 


### PR DESCRIPTION
what: Replaced the random number generated with a function call that
provides number of milliseconds since 1970 Jan 01 / 00:00:00 UTC
(Unix Epoch start). Since one user is adding material manually, they
will not add two items during the same millisecond. This should be
unique per user per row item.

Tests: OK

Consequences: none

Closes #39