### PR TITLE
Explicity Assigns RowId in Edit Function

### DIFF
--- a/app/controllers/buckets.js
+++ b/app/controllers/buckets.js
@@ -59,6 +59,7 @@ const create = (req, res, next) => {
 
 const update = (req, res, next) => {
   delete req.body._owner  // disallow owner reassignment.
+  req.body.data[req.params.id].DT_RowId = req.params.id
   req.bucket.update(req.body.data[req.params.id])
     .then(() => res.json({data: [req.body.data[req.params.id]]}))
     .catch(next)


### PR DESCRIPTION
Where: bucket controller (edit)

fixes: explicity assigns rowid back into the object so that multiple
edits can be made without throwing an error over not having rowId

tests OK

closes #49